### PR TITLE
Add BugfixHashableStateFactory to remedy collision issues

### DIFF
--- a/src/main/java/edu/umbc/cs/maple/palm/agent/PALMLearningAgent.java
+++ b/src/main/java/edu/umbc/cs/maple/palm/agent/PALMLearningAgent.java
@@ -193,7 +193,6 @@ public class PALMLearningAgent implements LearningAgent {
         State currentStateGrounded = e.stateSequence.get(e.stateSequence.size() - 1);
         State currentStateAbstract = task.mapState(currentStateGrounded);
         State pastStateAbstract = currentStateAbstract;
-        PALMModel model = getModel(task);
         int actionCount = 0;
 
         if(task.isPrimitive()) {
@@ -218,7 +217,7 @@ public class PALMLearningAgent implements LearningAgent {
             result = baseEnv.executeAction(action);
 
             SimulatedEnvironment simEnv = (SimulatedEnvironment)((EnvironmentServer)baseEnv).getEnvironmentDelegate();
-            simEnv.setAllowActionFromTerminalStates(false);
+            simEnv.setAllowActionFromTerminalStates(true);
 
             e.transition(result);
             currentStateAbstract = task.mapState(result.op);
@@ -284,6 +283,7 @@ public class PALMLearningAgent implements LearningAgent {
 
             StringBuilder resultString = new StringBuilder(action.toString());
             resultString.append(subtaskCompleted ? "+" : "--");
+            PALMModel model = getModel(task);
             if (subtaskCompleted) {
                 boolean atOrBeyondThreshold = model.updateModel(result, stepsTaken, params);
                 resultString.append(atOrBeyondThreshold ? "+" : "-");
@@ -294,9 +294,9 @@ public class PALMLearningAgent implements LearningAgent {
             subtasksExecuted.add(resultString.toString());
         }
 
-//        if (task.toString().contains("solve")) {
+        if (task.toString().contains("solve")) {
             System.out.println(subtasksExecuted.size() + " " + subtasksExecuted);
-//        }
+        }
 
         boolean taskCompleted = task.isComplete(currentStateAbstract);
         boolean parentShouldUpdateModel = taskCompleted || actionCount == 0;

--- a/src/main/java/edu/umbc/cs/maple/palm/rmax/agent/HashableStateActionPair.java
+++ b/src/main/java/edu/umbc/cs/maple/palm/rmax/agent/HashableStateActionPair.java
@@ -42,7 +42,7 @@ public class HashableStateActionPair {
     @Override
     public int hashCode() {
         int result = hs != null ? hs.hashCode() : 0;
-        result = 31 * result + (actionName != null ? actionName.hashCode() : 0);
+        result = 97 * result + (actionName != null ? actionName.hashCode() : 0);
         return result;
     }
 

--- a/src/main/java/edu/umbc/cs/maple/palm/rmax/agent/RmaxModel.java
+++ b/src/main/java/edu/umbc/cs/maple/palm/rmax/agent/RmaxModel.java
@@ -14,6 +14,7 @@ import edu.umbc.cs.maple.hierarchy.framework.StringFormat;
 import edu.umbc.cs.maple.hierarchy.framework.Task;
 import edu.umbc.cs.maple.palm.agent.PALMModel;
 import edu.umbc.cs.maple.palm.agent.PossibleOutcome;
+import edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.TaxiPutState;
 import edu.umbc.cs.maple.utilities.BurlapConstants;
 import edu.umbc.cs.maple.utilities.DiscountProvider;
 import edu.umbc.cs.maple.utilities.ExpectedStepsDiscountProvider;
@@ -23,6 +24,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static edu.umbc.cs.maple.taxi.TaxiConstants.ATT_GOAL_LOCATION;
+import static edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.PutStateMapper.PUT_PASSENGER_ALIAS;
 
 public abstract class RmaxModel extends PALMModel {
 
@@ -289,10 +293,21 @@ public abstract class RmaxModel extends PALMModel {
         if (hsPrimeToOutcomes == null) {
             String actionName = StringFormat.parameterizedActionName(a);
             HashableStateActionPair pair = new HashableStateActionPair(hs, actionName);
-            hsPrimeToOutcomes = new HashMap<HashableState, PossibleOutcome>();
+            hsPrimeToOutcomes = new HashMap<>();
             approximateTransitions.put(pair, hsPrimeToOutcomes);
         }
         PossibleOutcome outcome = hsPrimeToOutcomes.get(hsPrime);
+
+        if (outcome != null) {
+            State storedState = outcome.getOutcome().o;
+            HashableState storedHs = hashingFactory.hashState(storedState);
+            if (!storedHs.equals(hs)) {
+                throw new RuntimeException("hashcode collision");
+//                Map hsPrimeToOutcomesFromStoredHs = getHsPrimeToOutcomes(storedHs, a);
+//                Map hsPrimeToOutcomesFromNewerHs = getHsPrimeToOutcomes(hs, a);
+            }
+        }
+
         if (outcome == null) {
             double initialReward = 0.0;
             double initialProbability = 0.0;

--- a/src/main/java/edu/umbc/cs/maple/state/hashing/bugfix/BugfixHashableStateFactory.java
+++ b/src/main/java/edu/umbc/cs/maple/state/hashing/bugfix/BugfixHashableStateFactory.java
@@ -1,0 +1,54 @@
+package edu.umbc.cs.maple.state.hashing.bugfix;
+
+import burlap.mdp.core.state.State;
+import burlap.statehashing.HashableState;
+import burlap.statehashing.HashableStateFactory;
+
+
+public class BugfixHashableStateFactory implements HashableStateFactory {
+
+    /**
+     * Whether state evaluations of OO-MDPs are object identifier independent (the names of objects don't matter). By
+     * default it is independent.
+     */
+    protected boolean identifierIndependent = true;
+
+
+    /**
+     * Default constructor: object identifier independent and no hash code caching.
+     */
+    public BugfixHashableStateFactory(){
+
+    }
+
+    /**
+     * Initializes with no hash code caching.
+     * @param identifierIndependent if true then state evaluations for {@link burlap.mdp.core.oo.state.OOState}s are object identifier independent; if false then dependent.
+     */
+    public BugfixHashableStateFactory(boolean identifierIndependent){
+        this.identifierIndependent = identifierIndependent;
+    }
+
+
+    @Override
+    public HashableState hashState(State s) {
+        if(s instanceof IIBugfixHashableState || s instanceof IDBugfixHashableState){
+            return (HashableState)s;
+        }
+
+        if(identifierIndependent){
+            return new IIBugfixHashableState(s);
+        }
+        return new IDBugfixHashableState(s);
+    }
+
+
+    public boolean objectIdentifierIndependent() {
+        return this.identifierIndependent;
+    }
+
+
+
+
+
+}

--- a/src/main/java/edu/umbc/cs/maple/state/hashing/bugfix/IDBugfixHashableState.java
+++ b/src/main/java/edu/umbc/cs/maple/state/hashing/bugfix/IDBugfixHashableState.java
@@ -1,0 +1,196 @@
+package edu.umbc.cs.maple.state.hashing.bugfix;
+
+import burlap.mdp.core.oo.state.OOState;
+import burlap.mdp.core.oo.state.ObjectInstance;
+import burlap.mdp.core.state.State;
+import burlap.statehashing.HashableState;
+import burlap.statehashing.WrappedHashableState;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+public class IDBugfixHashableState extends WrappedHashableState {
+
+    public IDBugfixHashableState() {
+    }
+
+    public IDBugfixHashableState(State s) {
+        super(s);
+    }
+
+    @Override
+    public int hashCode() {
+        return computeHashCode(this.s);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == this){
+            return true;
+        }
+        if(!(obj instanceof HashableState)){
+            return false;
+        }
+        return statesEqual(this.s, ((HashableState)obj).s());
+    }
+
+
+    /**
+     * Computes the hash code for the input state.
+     * @param s the input state for which a hash code is to be computed
+     * @return the hash code
+     */
+    protected final int computeHashCode(State s){
+
+        if(s instanceof OOState){
+            return computeOOHashCode((OOState)s);
+        }
+        return computeFlatHashCode(s);
+
+    }
+
+    protected int computeOOHashCode(OOState s){
+
+        int [] hashCodes = new int[s.numObjects()];
+        List<ObjectInstance> objects = s.objects();
+        for(int i = 0; i < hashCodes.length; i++){
+            ObjectInstance o = objects.get(i);
+            int oHash = this.computeFlatHashCode(o);
+            int classNameHash = o.className().hashCode();
+            int nameHash = o.name().hashCode();
+            int totalHash = 7;
+            totalHash = 23 * totalHash + oHash;
+            totalHash = 23 * totalHash + classNameHash;
+            totalHash = 23 * totalHash + nameHash;
+            hashCodes[i] = totalHash;
+        }
+
+        //sort for invariance to order
+        Arrays.sort(hashCodes);
+        HashCodeBuilder hashCodeBuilder = new HashCodeBuilder(19, 67);
+        hashCodeBuilder.append(hashCodes);
+        return hashCodeBuilder.toHashCode();
+
+    }
+
+    protected int computeFlatHashCode(State s){
+
+        HashCodeBuilder hashCodeBuilder = new HashCodeBuilder(41, 89);
+
+        List<Object> keys = s.variableKeys();
+        for(Object key : keys){
+            Object value = s.get(key);
+            this.appendHashCodeForValue(hashCodeBuilder, key, value);
+        }
+
+        return hashCodeBuilder.toHashCode();
+    }
+
+    protected void appendHashCodeForValue(HashCodeBuilder hashCodeBuilder, Object key, Object value){
+        hashCodeBuilder.append(value);
+    }
+
+
+    /**
+     * Returns true if the two input states are equal. Equality respect this hashing factory's identifier independence
+     * setting.
+     * @param s1 a {@link State}
+     * @param s2 another {@link State} with which to compare
+     * @return true if s1 equals s2, false otherwise.
+     */
+    protected boolean statesEqual(State s1, State s2) {
+
+        if(s1 instanceof OOState && s2 instanceof OOState){
+            return ooStatesEqual((OOState)s1, (OOState)s2);
+        }
+        return flatStatesEqual(s1, s2);
+
+
+    }
+
+
+    protected boolean ooStatesEqual(OOState s1, OOState s2){
+        if (s1 == s2) {
+            return true;
+        }
+        if(s1.numObjects() != s2.numObjects()){
+            return false;
+        }
+
+        List<ObjectInstance> theseObjects = s1.objects();
+        for(ObjectInstance ob : theseObjects){
+            ObjectInstance oByName = s2.object(ob.name());
+            if(oByName == null){
+                return false;
+            }
+            if(!flatStatesEqual(ob, oByName)){
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected boolean flatStatesEqual(State s1, State s2){
+
+        if(s1 == s2){
+            return true;
+        }
+
+        List<Object> keys1 = s1.variableKeys();
+        List<Object> keys2 = s2.variableKeys();
+
+        if(keys1.size() != keys2.size()){
+            return false;
+        }
+
+        for(Object key : keys1){
+            Object v1 = s1.get(key);
+            Object v2 = s2.get(key);
+            if(!this.valuesEqual(key, v1, v2)){
+                return false;
+            }
+        }
+        return true;
+
+    }
+
+
+    /**
+     * Returns whether two values are equal.
+     * @param key the state variable key
+     * @param v1 the first value to compare
+     * @param v2 the second value to compare
+     * @return true if v1 = v2; false otherwise
+     */
+    protected boolean valuesEqual(Object key, Object v1, Object v2){
+        if(v1.getClass().isArray() && v2.getClass().isArray()){
+            if (v1 instanceof long[]) {
+                return Arrays.equals((long[])v1, (long[])v2);
+            } else if (v1 instanceof int[]) {
+                return Arrays.equals((int[])v1, (int[])v2);
+            } else if (v1 instanceof short[]) {
+                return Arrays.equals((short[])v1, (short[])v2);
+            } else if (v1 instanceof char[]) {
+                return Arrays.equals((char[])v1, (char[])v2);
+            } else if (v1 instanceof byte[]) {
+                return Arrays.equals((byte[])v1, (byte[])v2);
+            } else if (v1 instanceof double[]) {
+                return Arrays.equals((double[])v1, (double[])v2);
+            } else if (v1 instanceof float[]) {
+                return Arrays.equals((float[])v1, (float[])v2);
+            } else if (v1 instanceof boolean[]) {
+                throw new RuntimeException("Error: Undefined behavior in hashcode computation on boolean[]");
+            } else {
+                // Not an array of primitives
+                return Arrays.equals((Object[])v1, (Object[])v2);
+            }
+        }
+        return v1.equals(v2);
+    }
+
+
+
+}

--- a/src/main/java/edu/umbc/cs/maple/state/hashing/bugfix/IIBugfixHashableState.java
+++ b/src/main/java/edu/umbc/cs/maple/state/hashing/bugfix/IIBugfixHashableState.java
@@ -1,0 +1,210 @@
+package edu.umbc.cs.maple.state.hashing.bugfix;
+
+import burlap.mdp.core.oo.state.OOState;
+import burlap.mdp.core.oo.state.OOStateUtilities;
+import burlap.mdp.core.oo.state.ObjectInstance;
+import burlap.mdp.core.state.State;
+import burlap.statehashing.HashableState;
+import burlap.statehashing.WrappedHashableState;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.*;
+
+public class IIBugfixHashableState extends WrappedHashableState {
+
+    public IIBugfixHashableState() {
+    }
+
+    public IIBugfixHashableState(State s) {
+        super(s);
+    }
+
+    @Override
+    public int hashCode() {
+        return computeHashCode(this.s);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == this){
+            return true;
+        }
+        if(!(obj instanceof HashableState)){
+            return false;
+        }
+        return statesEqual(this.s, ((HashableState)obj).s());
+    }
+
+
+    /**
+     * Computes the hash code for the input state.
+     * @param s the input state for which a hash code is to be computed
+     * @return the hash code
+     */
+    protected final int computeHashCode(State s){
+
+        if(s instanceof OOState){
+            return computeOOHashCode((OOState)s);
+        }
+        return computeFlatHashCode(s);
+
+    }
+
+    protected int computeOOHashCode(OOState s){
+
+        int [] hashCodes = new int[s.numObjects()];
+        List<ObjectInstance> objects = s.objects();
+        for(int i = 0; i < hashCodes.length; i++){
+            ObjectInstance o = objects.get(i);
+            int oHash = this.computeFlatHashCode(o);
+            int classNameHash = o.className().hashCode();
+            int totalHash = oHash + 31*classNameHash;
+            hashCodes[i] = totalHash;
+        }
+
+        //sort for invariance to order
+        Arrays.sort(hashCodes);
+        HashCodeBuilder hashCodeBuilder = new HashCodeBuilder(17, 31);
+        hashCodeBuilder.append(hashCodes);
+        return hashCodeBuilder.toHashCode();
+
+    }
+
+    protected int computeFlatHashCode(State s){
+
+        HashCodeBuilder hashCodeBuilder = new HashCodeBuilder(17, 31);
+
+        List<Object> keys = s.variableKeys();
+        for(Object key : keys){
+            Object value = s.get(key);
+            this.appendHashCodeForValue(hashCodeBuilder, key, value);
+        }
+
+        return hashCodeBuilder.toHashCode();
+    }
+
+    protected void appendHashCodeForValue(HashCodeBuilder hashCodeBuilder, Object key, Object value){
+        hashCodeBuilder.append(value);
+    }
+
+
+    /**
+     * Returns true if the two input states are equal. Equality respect this hashing factory's identifier independence
+     * setting.
+     * @param s1 a {@link State}
+     * @param s2 another {@link State} with which to compare
+     * @return true if s1 equals s2, false otherwise.
+     */
+    protected boolean statesEqual(State s1, State s2) {
+
+        if(s1 instanceof OOState && s2 instanceof OOState){
+            return ooStatesEqual((OOState)s1, (OOState)s2);
+        }
+        return flatStatesEqual(s1, s2);
+
+
+    }
+
+
+    protected boolean ooStatesEqual(OOState s1, OOState s2){
+        if(s1 == s2){
+            return true;
+        }
+        if(s1.numObjects() != s2.numObjects()){
+            return false;
+        }
+
+        Set<String> matchedObjects = new HashSet<String>();
+        for(Map.Entry<String, List<ObjectInstance>> e1 : OOStateUtilities.objectsByClass(s1).entrySet()){
+            String oclass = e1.getKey();
+            List<ObjectInstance> objects = e1.getValue();
+
+            List<ObjectInstance> oobjects = s2.objectsOfClass(oclass);
+            if(objects.size() != oobjects.size()){
+                return false;
+            }
+
+            for(ObjectInstance o : objects){
+                boolean foundMatch = false;
+                for(ObjectInstance oo : oobjects){
+                    String ooname = oo.name();
+                    if(matchedObjects.contains(ooname)){
+                        continue;
+                    }
+                    if(flatStatesEqual(o, oo)){
+                        foundMatch = true;
+                        matchedObjects.add(ooname);
+                        break;
+                    }
+                }
+                if(!foundMatch){
+                    return false;
+                }
+            }
+
+        }
+
+        return true;
+    }
+
+    protected boolean flatStatesEqual(State s1, State s2){
+
+        if(s1 == s2){
+            return true;
+        }
+
+        List<Object> keys1 = s1.variableKeys();
+        List<Object> keys2 = s2.variableKeys();
+
+        if(keys1.size() != keys2.size()){
+            return false;
+        }
+
+        for(Object key : keys1){
+            Object v1 = s1.get(key);
+            Object v2 = s2.get(key);
+            if(!this.valuesEqual(key, v1, v2)){
+                return false;
+            }
+        }
+        return true;
+
+    }
+
+
+
+    /**
+     * Returns whether two values are equal.
+     * @param key the state variable key
+     * @param v1 the first value to compare
+     * @param v2 the second value to compare
+     * @return true if v1 = v2; false otherwise
+     */
+    protected boolean valuesEqual(Object key, Object v1, Object v2){
+        if(v1.getClass().isArray() && v2.getClass().isArray()){
+            if (v1 instanceof long[]) {
+                return Arrays.equals((long[])v1, (long[])v2);
+            } else if (v1 instanceof int[]) {
+                return Arrays.equals((int[])v1, (int[])v2);
+            } else if (v1 instanceof short[]) {
+                return Arrays.equals((short[])v1, (short[])v2);
+            } else if (v1 instanceof char[]) {
+                return Arrays.equals((char[])v1, (char[])v2);
+            } else if (v1 instanceof byte[]) {
+                return Arrays.equals((byte[])v1, (byte[])v2);
+            } else if (v1 instanceof double[]) {
+                return Arrays.equals((double[])v1, (double[])v2);
+            } else if (v1 instanceof float[]) {
+                return Arrays.equals((float[])v1, (float[])v2);
+            } else if (v1 instanceof boolean[]) {
+
+            } else {
+                // Not an array of primitives
+                return Arrays.equals((Object[])v1, (Object[])v2);
+            }
+        }
+        return v1.equals(v2);
+    }
+
+
+}

--- a/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/nav/state/TaxiNavState.java
+++ b/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/nav/state/TaxiNavState.java
@@ -62,7 +62,7 @@ public class TaxiNavState implements MutableOOState, DeepCopyForShallowCopyState
     }
 
     public Map<String, TaxiNavWall> touchWalls(){
-        this.walls = new HashMap<String, TaxiNavWall>(walls);
+        this.walls = new HashMap<>(walls);
         return walls;
     }
 
@@ -108,11 +108,11 @@ public class TaxiNavState implements MutableOOState, DeepCopyForShallowCopyState
     @Override
     public List<ObjectInstance> objectsOfClass(String oclass) {
         if(oclass.equals(CLASS_TAXI))
-            return taxi == null ? new ArrayList<ObjectInstance>() : Arrays.<ObjectInstance>asList(taxi);
+            return taxi == null ? new ArrayList<>() : Arrays.<ObjectInstance>asList(taxi);
         else if(oclass.equals(CLASS_LOCATION))
-            return new ArrayList<ObjectInstance>(locations.values());
+            return new ArrayList<>(locations.values());
         else if(oclass.equals(CLASS_WALL))
-            return new ArrayList<ObjectInstance>(walls.values());
+            return new ArrayList<>(walls.values());
         throw new RuntimeException("No object class " + oclass);
     }
 

--- a/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/PutPutdownActionType.java
+++ b/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/PutPutdownActionType.java
@@ -4,6 +4,7 @@ import burlap.mdp.core.oo.ObjectParameterizedAction;
 import burlap.mdp.core.oo.state.ObjectInstance;
 import burlap.mdp.core.state.State;
 import burlap.mdp.singleagent.oo.ObjectParameterizedActionType;
+import edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.TaxiPutAgent;
 import edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.TaxiPutState;
 
 import static edu.umbc.cs.maple.taxi.TaxiConstants.*;
@@ -19,7 +20,8 @@ public class PutPutdownActionType extends ObjectParameterizedActionType {
         String[] params = objectParameterizedAction.getObjectParameters();
         String passengerName = params[0];
         ObjectInstance passenger = state.object(passengerName);
-        String taxiLoc = (String)state.getTaxiAtt(ATT_LOCATION);
+        TaxiPutAgent taxi = state.getTaxi();
+        String taxiLoc = (String)taxi.get(ATT_LOCATION);
         return (passenger.get(ATT_LOCATION)).equals(ATT_VAL_IN_TAXI) && !taxiLoc.equals(ATT_VAL_ON_ROAD);
     }
 }

--- a/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/TaxiPutModel.java
+++ b/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/TaxiPutModel.java
@@ -10,6 +10,7 @@ import edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.TaxiPutAgent;
 import edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.TaxiPutPassenger;
 import edu.umbc.cs.maple.taxi.hierarchies.tasks.put.state.TaxiPutState;
 
+import javax.management.ObjectInstance;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +56,8 @@ public class TaxiPutModel implements FullStateModel {
         String passenger = a.getObjectParameters()[0];
 
         TaxiPutPassenger np = ns.touchPassenger(passenger);
-        String taxiLocation = (String) ns.getTaxiAtt(ATT_LOCATION);
+        TaxiPutAgent taxi = ns.getTaxi();
+        String taxiLocation = (String) taxi.get(ATT_LOCATION);
         np.set(ATT_LOCATION, taxiLocation);
 
         tps.add(new StateTransitionProb(ns, 1));

--- a/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/state/TaxiPutPassenger.java
+++ b/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/state/TaxiPutPassenger.java
@@ -10,10 +10,6 @@ import static edu.umbc.cs.maple.taxi.TaxiConstants.*;
 
 public class TaxiPutPassenger extends MutableObject {
 
-    /**
-     * current location, whether they are in taxi, the goal, whether they haven been picked up
-     * whether they have just been picked up and haven't changed goal
-     */
     private final static List<Object> keys = Arrays.<Object>asList(
             ATT_GOAL_LOCATION,
             ATT_LOCATION

--- a/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/state/TaxiPutState.java
+++ b/src/main/java/edu/umbc/cs/maple/taxi/hierarchies/tasks/put/state/TaxiPutState.java
@@ -82,11 +82,11 @@ public class TaxiPutState extends TaxiGetPutState implements DeepCopyForShallowC
     @Override
     public List<ObjectInstance> objectsOfClass(String oclass) {
         if(oclass.equals(CLASS_TAXI))
-            return taxi == null ? new ArrayList<ObjectInstance>() : Arrays.<ObjectInstance>asList(taxi);
+            return taxi == null ? new ArrayList<>() : Arrays.<ObjectInstance>asList(taxi);
         if(oclass.equals(CLASS_PASSENGER))
-            return new ArrayList<ObjectInstance>(passengers.values());
+            return new ArrayList<>(passengers.values());
         if(oclass.equals(CLASS_LOCATION))
-            return new ArrayList<ObjectInstance>(locations.values());
+            return new ArrayList<>(locations.values());
         throw new RuntimeException("No object class " + oclass);
     }
 
@@ -174,7 +174,7 @@ public class TaxiPutState extends TaxiGetPutState implements DeepCopyForShallowC
     }
 
     public Map<String, TaxiPutPassenger> touchPassengers(){
-        this.passengers = new HashMap<String, TaxiPutPassenger>(passengers);
+        this.passengers = new HashMap<>(passengers);
         return passengers;
     }
 
@@ -188,13 +188,6 @@ public class TaxiPutState extends TaxiGetPutState implements DeepCopyForShallowC
     public Map<String, TaxiPutLocation> touchLocations(){
         this.locations = new HashMap<>(locations);
         return locations;
-    }
-
-    public Object getTaxiAtt(String attName) {
-        if (taxi == null) {
-            return null;
-        }
-        return taxi.get(attName);
     }
 
     @Override
@@ -227,8 +220,8 @@ public class TaxiPutState extends TaxiGetPutState implements DeepCopyForShallowC
     @Override
     public int hashCode() {
         int result = taxi != null ? taxi.hashCode() : 0;
-        result = 31 * result + (passengers != null ? passengers.hashCode() : 0);
-        result = 31 * result + (locations != null ? locations.hashCode() : 0);
+        result = 17 * result + (passengers != null ? passengers.hashCode() : 0);
+        result = 73 * result + (locations != null ? locations.hashCode() : 0);
         return result;
     }
 
@@ -239,5 +232,9 @@ public class TaxiPutState extends TaxiGetPutState implements DeepCopyForShallowC
         copy.touchPassengers();
         copy.touchLocations();
         return copy;
+    }
+
+    public TaxiPutAgent getTaxi() {
+        return taxi;
     }
 }

--- a/src/main/java/edu/umbc/cs/maple/testing/AMDPPlanTest.java
+++ b/src/main/java/edu/umbc/cs/maple/testing/AMDPPlanTest.java
@@ -12,6 +12,7 @@ import edu.umbc.cs.maple.cleanup.hierarchies.CleanupHierarchy;
 import edu.umbc.cs.maple.cleanup.hierarchies.CleanupHierarchyAMDP;
 import edu.umbc.cs.maple.config.ExperimentConfig;
 import edu.umbc.cs.maple.hierarchy.framework.Task;
+import edu.umbc.cs.maple.state.hashing.bugfix.BugfixHashableStateFactory;
 import edu.umbc.cs.maple.state.hashing.cached.CachedHashableStateFactory;
 import edu.umbc.cs.maple.taxi.TaxiVisualizer;
 import edu.umbc.cs.maple.taxi.hierarchies.TaxiHierarchy;
@@ -70,7 +71,7 @@ public class AMDPPlanTest {
 //        CleanupHierarchy hierarchy = new CleanupHierarchyAMDP();
         Task palmRoot = hierarchy.createHierarchy(config, true);
         OOSADomain base = hierarchy.getBaseDomain();
-        HashableStateFactory hashingFactory = new SimpleHashableStateFactory(false);
+        HashableStateFactory hashingFactory = new BugfixHashableStateFactory(false);
 //        HashableStateFactory hashingFactory = new CachedHashableStateFactory(false);
         plan(config, palmRoot, s, hashingFactory, base);
     }

--- a/src/main/java/edu/umbc/cs/maple/testing/AgentType.java
+++ b/src/main/java/edu/umbc/cs/maple/testing/AgentType.java
@@ -15,6 +15,7 @@ import edu.umbc.cs.maple.palm.rmax.agent.ExpectedRmaxModelGenerator;
 import edu.umbc.cs.maple.palm.rmax.agent.ExpertNavModelGenerator;
 import edu.umbc.cs.maple.palm.rmax.agent.PALMRmaxModelGenerator;
 import edu.umbc.cs.maple.rmaxq.agent.RmaxQLearningAgent;
+import edu.umbc.cs.maple.state.hashing.bugfix.BugfixHashableStateFactory;
 import edu.umbc.cs.maple.state.hashing.cached.CachedHashableStateFactory;
 
 import java.util.Arrays;
@@ -127,7 +128,8 @@ public enum AgentType {
 
     public static HashableStateFactory initializeHashableStateFactory(boolean identifierIndependent) {
 //        return new CachedHashableStateFactory(identifierIndependent);
-        return new SimpleHashableStateFactory(identifierIndependent);
+//        return new SimpleHashableStateFactory(identifierIndependent);
+        return new BugfixHashableStateFactory(identifierIndependent);
     }
 
     public static LearningAgentFactory generate(String agentTypeString, ExperimentConfig config, Task expertRoot, Task hierGenRoot, Task qLearningWrapper) {

--- a/src/main/resources/config/taxi/jwtest.yaml
+++ b/src/main/resources/config/taxi/jwtest.yaml
@@ -1,18 +1,22 @@
 domain: !!edu.umbc.cs.maple.config.taxi.TaxiConfig
-  state: classic-2passengers
-  correct_move: 0.9
+  state: medium-3passengers
+  correct_move: 1.0
   fickle: 0.00
 
 agents:
-#  - palmExpert
+#  - rmaxqExpert
+#  - rmaxqHierGen
+  - palmExpert
+#  - palmExpertWithNavGiven
+#  - palmHierGen
 #  - kappaExpert
-  - palmHierGen
-  - kappaHierGen
+#  - kappaHierGen
+#  - qLearning
 
-seed: 532429
-episodes: 100
+seed: 666444333
+episodes: 200
 max_steps: 1000
-trials: 20
+trials: 1
 gamma: 0.95
 
 identifier_independent: false
@@ -21,13 +25,13 @@ planning:
 
 rmax:
   vmax: 10.0
-  threshold: 5
-  max_delta: 0.0001
-  max_delta_rmaxq: 0.0001
+  threshold: 3
+  max_delta: 0.0000001
+  max_delta_rmaxq: 0.0000001
   max_iterations_in_model: 1000
   use_multitime_model: true
   wait_for_children: true
-  use_model_sharing: false
+  use_model_sharing: true
 
 
 output:
@@ -41,7 +45,7 @@ output:
     width: 500
     height: 230
     columns: 2
-    max_height: 600
+    max_height: 693
     trial_mode: MOST_RECENT_AND_AVERAGE
 
     metrics:
@@ -50,9 +54,10 @@ output:
       - CUMULATIVE_REWARD_PER_EPISODE
 
   visualizer:
-    enabled: false
+    enabled: true
     episodes: true
     width: 5
     height: 5
-    
+   
+
 

--- a/src/main/resources/config/taxi/kappa-medium-multi.yaml
+++ b/src/main/resources/config/taxi/kappa-medium-multi.yaml
@@ -1,24 +1,19 @@
 domain: !!edu.umbc.cs.maple.config.taxi.TaxiConfig
-  state: classic-2passengers
+  state: medium-3passengers
   correct_move: 1.0
-  fickle: 0.06
+  fickle: 0.00
 
 agents:
-#    - rmaxqExpert
-  #  - rmaxqHierGen
-    - palmExpert
-#    - palmExpertWithNavGiven
-#    - palmHierGen
-#    - kappaExpert
-#    - kappaHierGen
-#    - qLearning
-episodes: 1000
-max_steps: 100000
+  - palmExpert
+  - kappaExpert
+  - palmHierGen
+  - kappaHierGen
+
+seed: 3344567
+episodes: 200
+max_steps: 1000
 trials: 1
-gamma: 0.99
-
-seed: 7543221
-
+gamma: 0.95
 
 identifier_independent: false
 planning:
@@ -26,9 +21,9 @@ planning:
 
 rmax:
   vmax: 10.0
-  threshold: 10
-  max_delta: 0.0001
-  max_delta_rmaxq: 0.0001
+  threshold: 3
+  max_delta: 0.000001
+  max_delta_rmaxq: 0.000001
   max_iterations_in_model: 1000
   use_multitime_model: true
   wait_for_children: true
@@ -38,7 +33,7 @@ rmax:
 output:
   csv:
     enabled: true
-    output: results/pex-classic-2-fickle.csv
+    output: results/classic.csv
 
   chart:
     enabled: true
@@ -60,3 +55,4 @@ output:
     width: 5
     height: 5
     
+

--- a/src/main/resources/config/taxi/medium-multi.yaml
+++ b/src/main/resources/config/taxi/medium-multi.yaml
@@ -1,5 +1,5 @@
 domain: !!edu.umbc.cs.maple.config.taxi.TaxiConfig
-  state: medium-4passengers
+  state: medium-3passengers
   correct_move: 1.0
   fickle: 0.00
 
@@ -13,11 +13,11 @@ agents:
 #  - kappaHierGen
 #  - qLearning
 
-seed: 86520100
-episodes: 100
+seed: 3344567
+episodes: 200
 max_steps: 100000
 trials: 1
-gamma: 0.99
+gamma: 0.95
 
 identifier_independent: false
 planning:
@@ -31,7 +31,7 @@ rmax:
   max_iterations_in_model: 1000
   use_multitime_model: true
   wait_for_children: true
-  use_model_sharing: false
+  use_model_sharing: true
 
 
 output:


### PR DESCRIPTION
The model sharing revealed issues with Burlap's default SimpleHashableStateFactory hashcode computation. States that did not differ by much would very likely collide.