### PR TITLE
bugfix parsing correct number of cleanup blocks

### DIFF
--- a/src/main/java/edu/umbc/cs/maple/cleanup/state/CleanupRandomStateGenerator.java
+++ b/src/main/java/edu/umbc/cs/maple/cleanup/state/CleanupRandomStateGenerator.java
@@ -1481,6 +1481,8 @@ public class CleanupRandomStateGenerator implements StateGenerator {
             //if block number is not specified, default 1 block
             numBlocks = 1;
             stateType+="-1blocks";
+        }else {
+            numBlocks = Integer.parseInt(numString);
         }
         State state;
         if (stateType.matches("oneRoomOneDoor" + blockNumberRegex)) {

--- a/src/main/resources/config/cleanup/cigar.yaml
+++ b/src/main/resources/config/cleanup/cigar.yaml
@@ -63,7 +63,7 @@ output:
       - CUMULATIVE_REWARD_PER_EPISODE
 
   visualizer:
-    enabled: false
+    enabled: true
     episodes: true
     width: 9
     height: 9


### PR DESCRIPTION
the regex was parsing to a string correctly but all decisions were being made on a separate variable.